### PR TITLE
Fixed casing of WiFiUdp.h include to support Linux

### DIFF
--- a/arduino_workspace/libraries/SonyHttpCamera/SonyHttpCamera.h
+++ b/arduino_workspace/libraries/SonyHttpCamera/SonyHttpCamera.h
@@ -11,7 +11,7 @@
 #include <DebuggingSerial.h>
 
 //#include "AsyncHTTPRequest_Generic.hpp"
-#include <WiFiUDP.h>
+#include <WiFiUdp.h>
 #include <HTTPClient.h>
 
 #define SHCAM_RXBUFF_UNIT     64


### PR DESCRIPTION
Linux file systems are typically case-sensitive. Fixing this include makes this compile-able on Linux.