### PR TITLE
pio: enlarge flash partition by removing ota2

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,5 +18,6 @@ data_dir = arduino_workspace/AlphaFairy/data
 platform = espressif32
 board = m5stick-c
 framework = arduino
-# no jtag pin on m5stick-c for debugging
+monitor_speed = 500000
+board_build.partitions = no_ota.csv
 # debug_tool = esp-prog


### PR DESCRIPTION
https://github.com/espressif/arduino-esp32/blob/master/tools/partitions/default.csv https://github.com/espressif/arduino-esp32/blob/master/tools/partitions/no_ota.csv https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html#offset-size